### PR TITLE
allow usage as a package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-png2ico
+module github.com/J-Siu/go-png2ico
 
 go 1.20
 


### PR DESCRIPTION
the tool is restricted to a cli command

when go get github.com/J-Siu/go-png2ico

go: github.com/J-Siu/go-png2ico@upgrade (v1.0.7) requires github.com/J-Siu/go-png2ico@v1.0.7: parsing go.mod:
        module declares its path as: go-png2ico
                but was required as: github.com/J-Siu/go-png2ico